### PR TITLE
Proposed change to deal with semver_redos

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=0.6"
   },
   "dependencies": {
-    "useragent": "1.1.0"
+    "useragent": "2.1.4"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
https://nodesecurity.io/advisories/semver_redos lists an issue with semver; useragent has since removed the direct semver dependency. I've run the test both before and after the useragent version change and seem to be getting the same results.